### PR TITLE
Update s3-notification-triggers.sh to correct lambda ARN

### DIFF
--- a/aws-event-triggering/s3-notification-triggers.sh
+++ b/aws-event-triggering/s3-notification-triggers.sh
@@ -79,7 +79,7 @@ aws s3api put-bucket-notification-configuration \
   --bucket "$bucket_name" \
   --notification-configuration '{
     "LambdaFunctionConfigurations": [{
-        "LambdaFunctionArn": "arn:aws:lambda:us-east-1:$aws_account_id:function:s3-lambda-function",
+        "LambdaFunctionArn": 'arn:aws:lambda:us-east-1:$aws_account_id:function:s3-lambda-function',
         "Events": ["s3:ObjectCreated:*"]
     }]
 }'


### PR DESCRIPTION
Hello Abhishek,

The "put-bucket-notification-configuration" block was failing as it was not able to identify the correct ARN for Lambda Configuration.

The issue was, The LambdaFunctionConfigurations code was considering everything under "Double quotes" as a plain text.
Basically it was treating $aws_account_id as a plain text instead of a variable.

After changing the double quotes to single quotes, it was able to recognize $aws_account_id as a variable and the script ran without any error.

Please, have a review.
Thank you for all your teachings, it's helping me a lot to pursue my career as a DevOps Engineer