### PR TITLE
 Check if the required arguments are provided <REPO_OWNER> <REPO_NAME>

### DIFF
--- a/github-api/list-users.sh
+++ b/github-api/list-users.sh
@@ -1,26 +1,25 @@
-# This line is known as the shebang. It specifies the interpreter to be used (in this case, Bash) to execute the script.
 #!/bin/bash
 
 # Description: GitHub API Integration (Script will list organization collaborators with read access)
 
-# This block of code checks whether the required command-line arguments are provided. If the number of arguments is not 2, it displays a message asking the user to provide the required arguments and exits the script with an exit status of 1.
+# Check if the required arguments are provided
 if [ $# -ne 2 ]; then
     echo "Please provide the required arguments: <REPO_OWNER> <REPO_NAME>"
     exit 1
 fi
 
-# GitHub API URL/ This line sets a variable API_URL to the GitHub API endpoint.
+# GitHub API URL
 API_URL="https://api.github.com"
 
-# GitHub username and personal access token / These lines assign the values of the environment variables username and token to the variables USERNAME and TOKEN respectively.
+# GitHub username and personal access token
 USERNAME=$username
 TOKEN=$token
 
-# User and Repository information / These lines store the first and second command-line arguments into the variables REPO_OWNER and REPO_NAME respectively.
+# User and Repository information
 REPO_OWNER=$1
 REPO_NAME=$2
 
-# Function to make a GET request to the GitHub API / This defines a function named github_api_get which takes an endpoint as an argument, constructs the full URL, and sends a GET request to the GitHub API with authentication using the curl command.
+# Function to make a GET request to the GitHub API
 function github_api_get {
     local endpoint="$1"
     local url="${API_URL}/${endpoint}"
@@ -29,7 +28,7 @@ function github_api_get {
     curl -s -u "${USERNAME}:${TOKEN}" "$url"
 }
 
-# Function to list users with read access to the repository / This defines a function named list_users_with_read_access which constructs the API endpoint for listing collaborators with read access to the repository, fetches the list of collaborators using the github_api_get function, filters the collaborators with read access, and then displays the list.
+# Function to list users with read access to the repository
 function list_users_with_read_access {
     local endpoint="repos/${REPO_OWNER}/${REPO_NAME}/collaborators"
 
@@ -46,6 +45,6 @@ function list_users_with_read_access {
 }
 
 # Main script
-# These lines first display a message indicating that users with read access to the specified repository are being listed, and then call the list_users_with_read_access function to perform the listing.
+
 echo "Listing users with read access to ${REPO_OWNER}/${REPO_NAME}..."
 list_users_with_read_access

--- a/github-api/list-users.sh
+++ b/github-api/list-users.sh
@@ -1,25 +1,26 @@
+# This line is known as the shebang. It specifies the interpreter to be used (in this case, Bash) to execute the script.
 #!/bin/bash
 
 # Description: GitHub API Integration (Script will list organization collaborators with read access)
 
-# Check if the required arguments are provided
+# This block of code checks whether the required command-line arguments are provided. If the number of arguments is not 2, it displays a message asking the user to provide the required arguments and exits the script with an exit status of 1.
 if [ $# -ne 2 ]; then
     echo "Please provide the required arguments: <REPO_OWNER> <REPO_NAME>"
     exit 1
 fi
 
-# GitHub API URL
+# GitHub API URL/ This line sets a variable API_URL to the GitHub API endpoint.
 API_URL="https://api.github.com"
 
-# GitHub username and personal access token
+# GitHub username and personal access token / These lines assign the values of the environment variables username and token to the variables USERNAME and TOKEN respectively.
 USERNAME=$username
 TOKEN=$token
 
-# User and Repository information
+# User and Repository information / These lines store the first and second command-line arguments into the variables REPO_OWNER and REPO_NAME respectively.
 REPO_OWNER=$1
 REPO_NAME=$2
 
-# Function to make a GET request to the GitHub API
+# Function to make a GET request to the GitHub API / This defines a function named github_api_get which takes an endpoint as an argument, constructs the full URL, and sends a GET request to the GitHub API with authentication using the curl command.
 function github_api_get {
     local endpoint="$1"
     local url="${API_URL}/${endpoint}"
@@ -28,7 +29,7 @@ function github_api_get {
     curl -s -u "${USERNAME}:${TOKEN}" "$url"
 }
 
-# Function to list users with read access to the repository
+# Function to list users with read access to the repository / This defines a function named list_users_with_read_access which constructs the API endpoint for listing collaborators with read access to the repository, fetches the list of collaborators using the github_api_get function, filters the collaborators with read access, and then displays the list.
 function list_users_with_read_access {
     local endpoint="repos/${REPO_OWNER}/${REPO_NAME}/collaborators"
 
@@ -45,6 +46,6 @@ function list_users_with_read_access {
 }
 
 # Main script
-
+# These lines first display a message indicating that users with read access to the specified repository are being listed, and then call the list_users_with_read_access function to perform the listing.
 echo "Listing users with read access to ${REPO_OWNER}/${REPO_NAME}..."
 list_users_with_read_access

--- a/github-api/list-users.sh
+++ b/github-api/list-users.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Description: GitHub API Integration (Script will list organization collaborators with read access)
+
+# Check if the required arguments are provided
+if [ $# -ne 2 ]; then
+    echo "Please provide the required arguments: <REPO_OWNER> <REPO_NAME>"
+    exit 1
+fi
+
 # GitHub API URL
 API_URL="https://api.github.com"
 

--- a/github-api/tracking.sh
+++ b/github-api/tracking.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#This Script will report the aws resourse usage
+
+set -x
+
+touch /home/ubuntu/hello.txt
+
+# list S3 bucket list
+echo "Print s3 bucket list"
+aws s3 ls
+
+# list EC2 instances list
+echo "Print EC2 instances list"
+aws ec2 describe-instances
+
+#list lambda
+echo "Print lambda functions"
+aws lambda list-functions
+
+#list IAM users
+echo "Print IAM users"
+aws iam list-users


### PR DESCRIPTION
This block of code checks whether the required command-line arguments are provided. If the number of arguments is not 2, it displays a message asking the user to provide the required arguments and exits the script with an exit status of 1.